### PR TITLE
Corrected bug by ensuring that the available_components property was …

### DIFF
--- a/node-tourcms.js
+++ b/node-tourcms.js
@@ -484,8 +484,12 @@ TourCMS.prototype.checkTourAvailability = function(a) {
 
     if(response.available_components == '\r\n')
       response.available_components = {component:[]};
-    else
+    else {
+      if (typeof response.available_components === 'string') {
+        response.available_components = {component:[]};
+      }
       response.available_components.component = [].concat(response.available_components.component);
+    }
 
     // Ensure each components contents are correct
     response.available_components.component.forEach(function(component) {


### PR DESCRIPTION
…not a string and initialised it as an object containing a component property

There is an error when making a call to checkTourAvailability() related to the available_components property being a string when it tries to assign the returned components. This happens when the capacity of the tour being checked is below the r1 (or other rate) value being sent or the entire tour is sold out.

This fixes the issue by just checking whether the available_components object is a string and if so changes to be an object with an empty components array.

This PR resolves all the issues for my use case and would be great if it was pulled into the master branch as currently I have to register an exception listener on the process to catch the error and assume that there is no capacity.